### PR TITLE
Add newlines after Network Active Plugins

### DIFF
--- a/src/SystemInfo.php
+++ b/src/SystemInfo.php
@@ -279,7 +279,7 @@ SUHOSIN:                  <?php echo ( extension_loaded( 'suhosin' ) ) ? 'Your s
 		}
 
 		echo "\n";
-		echo '-- Network Active Plugins --';
+		echo '-- Network Active Plugins --', "\n\n";
 
 		$plugins        = wp_get_active_network_plugins();
 		$active_plugins = get_site_option( 'active_sitewide_plugins', array() );


### PR DESCRIPTION
Add newlines to be consistent with other sections.

Here's an extract from the System Info for my site on Multisite:

-- WordPress Active Plugins --

Bulk Delete: 6.0.0
WordPress Importer: 0.6.4


-- Network Active Plugins --BackWPup :3.6.8
GitHub Updater :7.4.0
MultiSite Upgrade - Set HTTP authentication :1.0

Note that there is a blank line after 'WordPress Active Plugins' but not after 'Network Active Plugins'.
